### PR TITLE
Specify pip3 requirement.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - pytest
-  - pip:
+  - pip3:
     - sphinx-autoapi


### PR DESCRIPTION
## Pull Request

### Cause
I Got an error creating the conda environment. The conda terminal said that the wrong version of pip may be used. 

### Fix
Change 'pip' to 'pip3' in environment file.

### Impact
None that I'm aware of

### Severity of issue
Low, although it gave me an error, it also warned me of what caused it.


- Ryan